### PR TITLE
Fixes to AiParser

### DIFF
--- a/Maple2.File.Parser/AiParser.cs
+++ b/Maple2.File.Parser/AiParser.cs
@@ -31,19 +31,53 @@ public class AiParser {
             var ai = new NpcAi();
             XmlNode? reservedNode = document.SelectSingleNode("npcAi/reserved");
             if (reservedNode != null) {
-                ai.Reserved = ParseChildren(reservedNode).ToList();
+                XmlNode? commentNode = reservedNode.PreviousSibling;
+                while (includeComments && commentNode is XmlComment {Value: not null} comment) {
+                    commentNode = commentNode.PreviousSibling;
+
+                    if (comment.Value.Trim() == "예약") continue; // Redundant comment
+                    ai.Reserved.Insert(0, new Comment {
+                        Value = comment.Value,
+                    });
+                }
+                ai.Reserved.AddRange(ParseChildren(reservedNode));
             }
             XmlNode? battleNode = document.SelectSingleNode("npcAi/battle");
             if (battleNode != null) {
-                ai.Battle = ParseChildren(battleNode).ToList();
+                XmlNode? commentNode = battleNode.PreviousSibling;
+                while (includeComments && commentNode is XmlComment {Value: not null} comment) {
+                    commentNode = commentNode.PreviousSibling;
+
+                    if (comment.Value.Trim() == "전투") continue; // Redundant comment
+                    ai.Battle.Insert(0, new Comment {
+                        Value = comment.Value,
+                    });
+                }
+                ai.Battle.AddRange(ParseChildren(battleNode));
             }
             XmlNode? battleEndNode = document.SelectSingleNode("npcAi/battleEnd");
             if (battleEndNode != null) {
-                ai.BattleEnd = ParseChildren(battleEndNode).ToList();
+                XmlNode? commentNode = battleEndNode.PreviousSibling;
+                while (includeComments && commentNode is XmlComment {Value: not null} comment) {
+                    commentNode = commentNode.PreviousSibling;
+                    ai.BattleEnd.Insert(0, new Comment {
+                        Value = comment.Value,
+                    });
+                }
+                ai.BattleEnd.AddRange(ParseChildren(battleEndNode));
             }
             XmlNode? aiPresetsNode = document.SelectSingleNode("npcAi/aiPresets");
             if (aiPresetsNode != null) {
-                ai.AiPresets = ParseChildren(aiPresetsNode).ToList();
+                XmlNode? commentNode = aiPresetsNode.PreviousSibling;
+                while (includeComments && commentNode is XmlComment {Value: not null} comment) {
+                    commentNode = commentNode.PreviousSibling;
+
+                    if (comment.Value.StartsWith("ai프리셋 모음")) continue; // Redundant comment
+                    ai.AiPresets.Insert(0, new Comment {
+                        Value = comment.Value,
+                    });
+                }
+                ai.AiPresets.AddRange(ParseChildren(aiPresetsNode));
             }
 
             // removing the AI/ prefix because the <aiInfo path> attribute is relative to AI
@@ -115,7 +149,7 @@ public class AiParser {
             "removeslaves" => ParseAttributes<RemoveSlavesNode>(xml),
             "createrandomroom" => ParseAttributes<CreateRandomRoomNode>(xml),
             "createinteractobject" => ParseAttributes<CreateInteractObjectNode>(xml),
-            "removeme" => ParseAttributes<RemoveNode>(xml),
+            "removeme" => ParseAttributes<RemoveMeNode>(xml),
             "suicide" => ParseAttributes<SuicideNode>(xml),
             // Conditions
             "hpover" => ParseAttributes<HpOverCondition>(xml),

--- a/Maple2.File.Parser/Enum/AiNodes.cs
+++ b/Maple2.File.Parser/Enum/AiNodes.cs
@@ -66,6 +66,6 @@ public enum NodeBuffType {
 }
 
 public enum NodePopupType {
-    talk,
-    cutin,
+    talk = 1,
+    cutin = 2,
 }

--- a/Maple2.File.Parser/Maple2.File.Parser.csproj
+++ b/Maple2.File.Parser/Maple2.File.Parser.csproj
@@ -13,7 +13,7 @@
         <PackageTags>MapleStory2, File, Parser, m2d, xml</PackageTags>
         <!-- Use following lines to write the generated files to disk. -->
         <EmitCompilerGeneratedFiles Condition=" '$(Configuration)' == 'Debug' ">true</EmitCompilerGeneratedFiles>
-        <PackageVersion>2.1.6</PackageVersion>
+        <PackageVersion>2.1.7</PackageVersion>
         <TargetFramework>net7.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/Maple2.File.Parser/Xml/AI/Entry.cs
+++ b/Maple2.File.Parser/Xml/AI/Entry.cs
@@ -5,7 +5,7 @@ namespace Maple2.File.Parser.Xml.AI;
 public abstract class Entry {
     public string name;
 
-    public List<Entry> Entries;
+    public List<Entry> Entries = new ();
 }
 
 public class Comment : Entry {

--- a/Maple2.File.Parser/Xml/AI/Node/RemoveNode.cs
+++ b/Maple2.File.Parser/Xml/AI/Node/RemoveNode.cs
@@ -1,6 +1,6 @@
 ﻿namespace Maple2.File.Parser.Xml.AI;
 
-public class RemoveNode : NodeEntry { }
+public class RemoveMeNode : NodeEntry { }
 
 public class SuicideNode : NodeEntry { }
 

--- a/Maple2.File.Parser/Xml/AI/Node/SidePopupNode.cs
+++ b/Maple2.File.Parser/Xml/AI/Node/SidePopupNode.cs
@@ -3,7 +3,7 @@
 namespace Maple2.File.Parser.Xml.AI;
 
 public class SidePopupNode : NodeEntry {
-    public NodePopupType type;
+    public NodePopupType type = NodePopupType.talk;
     public string illust = string.Empty;
     public int duration;
     public string script = string.Empty;

--- a/Maple2.File.Parser/Xml/AI/Node/SkillNode.cs
+++ b/Maple2.File.Parser/Xml/AI/Node/SkillNode.cs
@@ -4,6 +4,7 @@ namespace Maple2.File.Parser.Xml.AI;
 
 public class SkillNode : NodeEntry {
     public int idx;
+    public int id;
     public short level;
     public int prob = 100;
     public bool sequence;


### PR DESCRIPTION
- Includes top-level comment nodes (with minor filtering)
- Renames `RemoveNode` to `RemoveMeNode` to better align with XML
- Initialize `Entry.Entries` by default
- Add `id` field to `SkillNode`
- Align enum values for `NodePopupType` with game packet values