### PR TITLE
Quest UsePeriod Fix

### DIFF
--- a/Maple2.File.Parser/Maple2.File.Parser.csproj
+++ b/Maple2.File.Parser/Maple2.File.Parser.csproj
@@ -13,7 +13,7 @@
         <PackageTags>MapleStory2, File, Parser, m2d, xml</PackageTags>
         <!-- Use following lines to write the generated files to disk. -->
         <EmitCompilerGeneratedFiles Condition=" '$(Configuration)' == 'Debug' ">true</EmitCompilerGeneratedFiles>
-        <PackageVersion>2.1.32</PackageVersion>
+        <PackageVersion>2.1.33</PackageVersion>
         <TargetFramework>net8.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Maple2.File.Parser/Xml/Quest/Basic.cs
+++ b/Maple2.File.Parser/Xml/Quest/Basic.cs
@@ -23,6 +23,6 @@ public partial class Basic {
     [M2dEnum] public AllianceRank rank = AllianceRank.Unknown;
     [XmlAttribute] public bool usePostbox;
     [XmlAttribute] public bool useReEntryHiddenMap;
-    [M2dEnum] public Enum.DayOfWeek usePeriod = Enum.DayOfWeek.unknown;
+    [XmlAttribute] public string usePeriod = string.Empty;
     [M2dArray] public QuestPropertyType[] property;
 }


### PR DESCRIPTION
`usePeriod` can either be a string/enum or an int. Changing the type to be string and this can ingested properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the package version of the MapleStory2 File Parser to 2.1.33.
	- Enhanced flexibility by changing the `usePeriod` field from an enumeration to a string in the `Basic` class.

- **Bug Fixes**
	- Improved handling of the `usePeriod` attribute for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->