### PR TITLE
Fix ItemVariationTable

### DIFF
--- a/Maple2.File.Parser/Maple2.File.Parser.csproj
+++ b/Maple2.File.Parser/Maple2.File.Parser.csproj
@@ -13,7 +13,7 @@
         <PackageTags>MapleStory2, File, Parser, m2d, xml</PackageTags>
         <!-- Use following lines to write the generated files to disk. -->
         <EmitCompilerGeneratedFiles Condition=" '$(Configuration)' == 'Debug' ">true</EmitCompilerGeneratedFiles>
-        <PackageVersion>2.2.0</PackageVersion>
+        <PackageVersion>2.2.1</PackageVersion>
         <TargetFramework>net8.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Maple2.File.Parser/Xml/Table/ItemOptionVariation.cs
+++ b/Maple2.File.Parser/Xml/Table/ItemOptionVariation.cs
@@ -6,7 +6,7 @@ namespace Maple2.File.Parser.Xml.Table;
 // ./data/xml/table/itemoptionvariation.xml
 [XmlRoot("ms2")]
 public partial class ItemOptionVariation {
-    [M2dFeatureLocale(Selector = "OptionName")] private IList<Option> _option;
+    [M2dFeatureLocale(Selector = "OptionName|OptionRateMin|OptionValueMin")] private IList<Option> _option;
 
     public partial class Option : IFeatureLocale {
         [XmlAttribute] public string OptionName = string.Empty;

--- a/Maple2.File.Parser/Xml/Table/ItemOptionVariation.cs
+++ b/Maple2.File.Parser/Xml/Table/ItemOptionVariation.cs
@@ -6,7 +6,7 @@ namespace Maple2.File.Parser.Xml.Table;
 // ./data/xml/table/itemoptionvariation.xml
 [XmlRoot("ms2")]
 public partial class ItemOptionVariation {
-    [M2dFeatureLocale(Selector = "OptionName|OptionRateMin|OptionValueMin")] private IList<Option> _option;
+    [M2dFeatureLocale(Selector = "OptionName|OptionRateMin|OptionRateMax|OptionValueMin|OptionValueMax")] private IList<Option> _option;
 
     public partial class Option : IFeatureLocale {
         [XmlAttribute] public string OptionName = string.Empty;


### PR DESCRIPTION
This is to avoid having multiple same optionName entries to be overwritten

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the release version from 2.2.0 to 2.2.1.
- **Refactor**
	- Enhanced data processing for item options by expanding the configuration criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->