### PR TITLE
Parse Season Data

### DIFF
--- a/Maple2.File.Parser/Maple2.File.Parser.csproj
+++ b/Maple2.File.Parser/Maple2.File.Parser.csproj
@@ -13,7 +13,7 @@
         <PackageTags>MapleStory2, File, Parser, m2d, xml</PackageTags>
         <!-- Use following lines to write the generated files to disk. -->
         <EmitCompilerGeneratedFiles Condition=" '$(Configuration)' == 'Debug' ">true</EmitCompilerGeneratedFiles>
-        <PackageVersion>2.2.8</PackageVersion>
+        <PackageVersion>2.2.9</PackageVersion>
         <TargetFramework>net8.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Maple2.File.Parser/TableParser.cs
+++ b/Maple2.File.Parser/TableParser.cs
@@ -99,6 +99,7 @@ public class TableParser {
     private readonly XmlSerializer weddingRewardSerializer;
     private readonly XmlSerializer weddingSkillSerializer;
     private readonly XmlSerializer smartPushSerializer;
+    private readonly XmlSerializer seasonDataSerializer;
 
     private readonly string locale;
 
@@ -191,6 +192,7 @@ public class TableParser {
         weddingRewardSerializer = new XmlSerializer(typeof(WeddingRewardRoot));
         weddingSkillSerializer = new XmlSerializer(typeof(WeddingSkillRoot));
         smartPushSerializer = new XmlSerializer(typeof(SmartPushRoot));
+        seasonDataSerializer = new XmlSerializer(typeof(SeasonDataRoot));
 
         locale = FeatureLocaleFilter.Locale.ToLower();
 
@@ -1397,6 +1399,105 @@ public class TableParser {
 
         foreach (SmartPush entry in data.push) {
             yield return (entry.id, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataArcade() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_arcade.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataBossColosseum() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_bosscolosseum.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataDarkStream() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_darkstream.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataGuildPvp() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_guildpvp.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataMapleSurvival() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_maplesurvival.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataMapleSurvivalSquad() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_maplesurvival_squad.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataPvp() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_pvp.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataUgcMapCommendation() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_ugcmapcommendation.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
+        }
+    }
+
+    public IEnumerable<(int Id, SeasonData Data)> ParseSeasonDataWorldChampion() {
+        string xml = Sanitizer.RemoveEmpty(xmlReader.GetString(xmlReader.GetEntry($"table/{locale}/seasondata_worldchampion.xml")));
+        var reader = XmlReader.Create(new StringReader(xml));
+        var data = seasonDataSerializer.Deserialize(reader) as SeasonDataRoot;
+        Debug.Assert(data != null);
+
+        foreach (SeasonData entry in data.Season) {
+            yield return (entry.seasonID, entry);
         }
     }
 }

--- a/Maple2.File.Parser/Xml/Table/SeasonData.cs
+++ b/Maple2.File.Parser/Xml/Table/SeasonData.cs
@@ -1,0 +1,31 @@
+﻿using System.Xml.Serialization;
+
+namespace Maple2.File.Parser.Xml.Table;
+
+// ./data/xml/table/na/seasondata_arcade.xml
+// ./data/xml/table/na/seasondata_bosscolosseum.xml
+// ./data/xml/table/na/seasondata_darkstream.xml
+// ./data/xml/table/na/seasondata_guildpvp.xml
+// ./data/xml/table/na/seasondata_maplesurvival.xml
+// ./data/xml/table/na/seasondata_maplesurvival_squad.xml
+// ./data/xml/table/na/seasondata_pvp.xml
+// ./data/xml/table/na/seasondata_ugcmapcommendation.xml
+// ./data/xml/table/na/seasondata_worldchampion.xml
+[XmlRoot("ms2")]
+public class SeasonDataRoot {
+    [XmlElement] public List<SeasonData> Season;
+}
+
+public partial class SeasonData {
+    [XmlAttribute] public int seasonID;
+    [XmlAttribute] public string seasonName = string.Empty;
+    [XmlAttribute] public string eventStart = string.Empty;
+    [XmlAttribute] public string eventEnd = string.Empty;
+    [XmlAttribute] public int grade1;
+    [XmlAttribute] public int grade2;
+    [XmlAttribute] public int grade3;
+    [XmlAttribute] public int grade4;
+    [XmlAttribute] public int grade5;
+    [XmlAttribute] public int grade6;
+    [XmlAttribute] public int grade7;
+}

--- a/Maple2.File.Tests/TableParserTest.cs
+++ b/Maple2.File.Tests/TableParserTest.cs
@@ -678,5 +678,44 @@ public class TableParserTest {
             continue;
         }
     }
+
+    [TestMethod]
+    public void TestSeasonData() {
+        foreach ((_, _) in _parser.ParseSeasonDataArcade()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataBossColosseum()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataDarkStream()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataGuildPvp()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataMapleSurvival()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataMapleSurvivalSquad()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataPvp()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataUgcMapCommendation()) {
+            continue;
+        }
+
+        foreach ((_, _) in _parser.ParseSeasonDataWorldChampion()) {
+            continue;
+        }
+    }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing and accessing seasonal data for various game modes, including arcade, boss colosseum, dark stream, guild PvP, maple survival, PvP, and more.
- **Tests**
  - Introduced tests to verify correct parsing of the new seasonal data types.
- **Chores**
  - Incremented the package version to 2.2.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->