### PR TITLE
Add BanWordParser and related unit tests

### DIFF
--- a/Maple2.File.Parser/BanWordParser.cs
+++ b/Maple2.File.Parser/BanWordParser.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics;
+using System.Xml;
+using System.Xml.Serialization;
+using Maple2.File.IO;
+using Maple2.File.IO.Crypto.Common;
+using Maple2.File.Parser.Xml.String;
+
+namespace Maple2.File.Parser;
+
+public class BanWordParser {
+    private readonly M2dReader xmlReader;
+    private readonly XmlSerializer nameSerializer;
+
+    public BanWordParser(M2dReader xmlReader) {
+        this.xmlReader = xmlReader;
+        nameSerializer = new XmlSerializer(typeof(StringMapping));
+    }
+
+    public IEnumerable<(int Id, string Name)> ParseBanWords() {
+        int i = 0;
+        foreach (PackFileEntry entry in xmlReader.Files.Where(entry => entry.Name.Contains("banword") && !entry.Name.Contains("ugc"))) {
+            XmlReader reader = xmlReader.GetXmlReader(entry);
+            var mapping = nameSerializer.Deserialize(reader) as StringMapping;
+
+            Debug.Assert(mapping != null);
+
+            Dictionary<int, string> banWords = mapping.key.ToDictionary(_ => i++, key => key.name);
+            foreach (var banWord in banWords) {
+                if (string.IsNullOrEmpty(banWord.Value)) {
+                    continue;
+                }
+                yield return (banWord.Key, banWord.Value);
+            }
+        }
+    }
+
+    public IEnumerable<(int Id, string Name)> ParseUgcBanWords() {
+        int i = 0;
+        foreach (PackFileEntry entry in xmlReader.Files.Where(entry => entry.Name.Contains("ugcbanword"))) {
+            XmlReader reader = xmlReader.GetXmlReader(entry);
+            var mapping = nameSerializer.Deserialize(reader) as StringMapping;
+
+            Debug.Assert(mapping != null);
+
+            Dictionary<int, string> banWords = mapping.key.ToDictionary(_ => i++, key => key.name);
+            foreach (var banWord in banWords) {
+                if (string.IsNullOrEmpty(banWord.Value)) {
+                    continue;
+                }
+                yield return (banWord.Key, banWord.Value);
+            }
+        }
+    }
+}

--- a/Maple2.File.Parser/Maple2.File.Parser.csproj
+++ b/Maple2.File.Parser/Maple2.File.Parser.csproj
@@ -13,7 +13,7 @@
         <PackageTags>MapleStory2, File, Parser, m2d, xml</PackageTags>
         <!-- Use following lines to write the generated files to disk. -->
         <EmitCompilerGeneratedFiles Condition=" '$(Configuration)' == 'Debug' ">true</EmitCompilerGeneratedFiles>
-        <PackageVersion>2.3.3</PackageVersion>
+        <PackageVersion>2.3.4</PackageVersion>
         <TargetFramework>net8.0</TargetFramework>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Maple2.File.Tests/BanWordParserTest.cs
+++ b/Maple2.File.Tests/BanWordParserTest.cs
@@ -1,0 +1,39 @@
+﻿using Maple2.File.Parser;
+using Maple2.File.Parser.Enum;
+using Maple2.File.Parser.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Maple2.File.Tests;
+
+[TestClass]
+public class BanWordParserTest {
+    [TestMethod]
+    public void TestBanWordParser() {
+        var locale = Locale.NA;
+        Filter.Load(TestUtils.XmlReader, locale.ToString(), "Live");
+        var parser = new BanWordParser(TestUtils.XmlReader);
+
+        int count = 0;
+        foreach ((int id, string name) in parser.ParseBanWords()) {
+            Assert.IsTrue(id >= 0);
+            Assert.IsFalse(string.IsNullOrEmpty(name));
+            count++;
+        }
+        Assert.AreEqual(6179, count);
+    }
+
+    [TestMethod]
+    public void TestUgcBanWordParser() {
+        var locale = Locale.NA;
+        Filter.Load(TestUtils.XmlReader, locale.ToString(), "Live");
+        var parser = new BanWordParser(TestUtils.XmlReader);
+
+        int count = 0;
+        foreach ((int id, string name) in parser.ParseUgcBanWords()) {
+            Assert.IsTrue(id >= 0);
+            Assert.IsFalse(string.IsNullOrEmpty(name));
+            count++;
+        }
+        Assert.AreEqual(1208, count);
+    }
+}


### PR DESCRIPTION
Introduces BanWordParser for parsing ban words and UGC ban words from XML files. Adds BanWordParserTest to verify correct parsing and updates project version to 2.3.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for parsing ban words, including separate handling for standard and UGC lists. Produces sequential IDs with non-empty names and aggregates results across all relevant data sources.
* Tests
  * Added unit tests validating parsing correctness and expected totals for both standard and UGC ban word lists.
* Chores
  * Bumped package version to 2.3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->